### PR TITLE
Adds a setting which can optionally disable death message togglability

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This mod adds death messages for:
 - And generally everything else
 
 There is also a command: `/toggle_death_messages` that toggles your death messages on and off
-They can be made untoggable and death messages will always sent if `public_death_messages_togglable` is
+They can be made untoggable and death messages will always be sent if `public_death_messages_togglable` is
 set to `false` in your `minetest.conf`
 
 **License**: GPLv3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This mod adds death messages for:
 - And generally everything else
 
 There is also a command: `/toggle_death_messages` that toggles your death messages on and off
-They can be made untoggable and death messages will always sent if `disable_death_message_toggling` is
+They can be made untoggable and death messages will always sent if `public_death_messages_togglable` is
 set to true in your minetest.conf
 
 **License**: GPLv3

--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ This mod adds death messages for:
 
 There is also a command: `/toggle_death_messages` that toggles your death messages on and off
 They can be made untoggable and death messages will always sent if `public_death_messages_togglable` is
-set to true in your minetest.conf
+set to `false` in your `minetest.conf`
 
 **License**: GPLv3

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This mod adds death messages for:
 - And generally everything else
 
 There is also a command: `/toggle_death_messages` that toggles your death messages on and off
-They can be made untoggable and death messages will always be sent if `public_death_messages_togglable` is
-set to `false` in your `minetest.conf`
+
+Death message toggleability can be disabled and they will always be enabled for all players if
+`public_death_messages_toggleable` is set to `false` in your `minetest.conf`
 
 **License**: GPLv3

--- a/README.md
+++ b/README.md
@@ -10,5 +10,7 @@ This mod adds death messages for:
 - And generally everything else
 
 There is also a command: `/toggle_death_messages` that toggles your death messages on and off
+They can be made untoggable and death messages will always sent if `disable_death_message_toggling` is
+set to true in your minetest.conf
 
 **License**: GPLv3

--- a/init.lua
+++ b/init.lua
@@ -58,15 +58,15 @@ local other = {
 }
 
 -- Settings are read from your minetest.conf
--- TOGGLABLE_DEATH_MESSAGES determines whether players can toggle their death messages.
--- If set to false, not only will they be untogglable, but death messages will always be sent. The default is true
-local TOGGLABLE_DEATH_MESSAGES = minetest.settings:get_bool("public_death_messages_togglable", true)
+-- TOGGLEABLE_DEATH_MESSAGES determines whether players can toggle their death messages.
+-- If set to false, not only will they be untoggleable, but death messages are always enabled. The default is true
+local TOGGLEABLE_DEATH_MESSAGES = minetest.settings:get_bool("public_death_messages_toggleable", true)
 
 function send_death_message(cause, victim, killer)
     local meta = victim:get_meta()
     local show_death_messages = meta:get_string('show_death_messages')
 
-    if TOGGLABLE_DEATH_MESSAGES == false or show_death_messages == '' or show_death_messages == 'yes' then
+    if TOGGLEABLE_DEATH_MESSAGES == false or show_death_messages == '' or show_death_messages == 'yes' then
         local death_message = cause[math.random(#cause)]
 
         if killer then
@@ -133,7 +133,7 @@ minetest.register_chatcommand('toggle_death_messages', {
         local meta = minetest.get_player_by_name(name):get_meta()
         local show_death_messages = meta:get_string('show_death_messages')
 
-        if TOGGLABLE_DEATH_MESSAGES == false then
+	if TOGGLEABLE_DEATH_MESSAGES == false then
 	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled on this server')))
 
         elseif show_death_messages == '' or show_death_messages == 'yes' then

--- a/init.lua
+++ b/init.lua
@@ -134,7 +134,7 @@ minetest.register_chatcommand('toggle_death_messages', {
         local show_death_messages = meta:get_string('show_death_messages')
 
         if TOGGLABLE_DEATH_MESSAGES == false then
-	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled in this server')))
+	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled on this server')))
 
         elseif show_death_messages == '' or show_death_messages == 'yes' then
             -- Turn death messages off

--- a/init.lua
+++ b/init.lua
@@ -58,15 +58,15 @@ local other = {
 }
 
 -- Settings are read from your minetest.conf
--- UNTOGGLABLE_DEATH_MESSAGES prevents all players from toggling their death messages if set to true,
--- and death messages will always be sent. The default is false
-local UNTOGGLABLE_DEATH_MESSAGES = minetest.settings:get_bool("public_death_messages_togglable", false)
+-- TOGGLABLE_DEATH_MESSAGES determines whether players can toggle their death messages.
+-- If set to false, not only will they be untogglable, but death messages will always be sent. The default is true
+local TOGGLABLE_DEATH_MESSAGES = minetest.settings:get_bool("public_death_messages_togglable", true)
 
 function send_death_message(cause, victim, killer)
     local meta = victim:get_meta()
     local show_death_messages = meta:get_string('show_death_messages')
 
-    if UNTOGGLABLE_DEATH_MESSAGES == true or show_death_messages == '' or show_death_messages == 'yes' then
+    if TOGGLABLE_DEATH_MESSAGES == false or show_death_messages == '' or show_death_messages == 'yes' then
         local death_message = cause[math.random(#cause)]
 
         if killer then
@@ -133,7 +133,7 @@ minetest.register_chatcommand('toggle_death_messages', {
         local meta = minetest.get_player_by_name(name):get_meta()
         local show_death_messages = meta:get_string('show_death_messages')
 
-        if UNTOGGLABLE_DEATH_MESSAGES == true then
+        if TOGGLABLE_DEATH_MESSAGES == false then
 	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Your death messages cannot be disabled in this server')))
 
         elseif show_death_messages == '' or show_death_messages == 'yes' then

--- a/init.lua
+++ b/init.lua
@@ -133,8 +133,8 @@ minetest.register_chatcommand('toggle_death_messages', {
         local meta = minetest.get_player_by_name(name):get_meta()
         local show_death_messages = meta:get_string('show_death_messages')
 
-	if TOGGLEABLE_DEATH_MESSAGES == false then
-	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled on this server')))
+        if TOGGLEABLE_DEATH_MESSAGES == false then
+            minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled on this server')))
 
         elseif show_death_messages == '' or show_death_messages == 'yes' then
             -- Turn death messages off

--- a/init.lua
+++ b/init.lua
@@ -134,7 +134,7 @@ minetest.register_chatcommand('toggle_death_messages', {
         local show_death_messages = meta:get_string('show_death_messages')
 
         if TOGGLABLE_DEATH_MESSAGES == false then
-	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Your death messages cannot be disabled in this server')))
+	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled in this server')))
 
         elseif show_death_messages == '' or show_death_messages == 'yes' then
             -- Turn death messages off

--- a/init.lua
+++ b/init.lua
@@ -57,11 +57,16 @@ local other = {
     NS('@1 did something fatal')
 }
 
+-- Settings are read from your minetest.conf
+-- UNTOGGLABLE_DEATH_MESSAGES prevents all players from toggling their death messages if set to true,
+-- and death messages will always be sent. The default is false
+UNTOGGLABLE_DEATH_MESSAGES = minetest.settings:get_bool("disable_public_death_message_toggling", false)
+
 function send_death_message(cause, victim, killer)
     local meta = victim:get_meta()
     local show_death_messages = meta:get_string('show_death_messages')
 
-    if show_death_messages == '' or show_death_messages == 'yes' then
+    if UNTOGGLABLE_DEATH_MESSAGES == true or show_death_messages == '' or show_death_messages == 'yes' then
         local death_message = cause[math.random(#cause)]
 
         if killer then
@@ -128,12 +133,16 @@ minetest.register_chatcommand('toggle_death_messages', {
         local meta = minetest.get_player_by_name(name):get_meta()
         local show_death_messages = meta:get_string('show_death_messages')
 
-        if show_death_messages == '' or show_death_messages == 'yes' then
+        if UNTOGGLABLE_DEATH_MESSAGES == true then
+	    -- Notifies the player that death messages cannot be toggled and are always enabled
+	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled here, all will be revealed!')))
+
+        elseif show_death_messages == '' or show_death_messages == 'yes' then
             -- Turn death messages off
             meta:set_string('show_death_messages', 'no')
             minetest.chat_send_player(name, minetest.colorize('green', S('You will no longer send death messages')))
             minetest.log('action', name .. ' disabled their death messages')
-        
+
         else
             -- Turn death messages on
             meta:set_string('show_death_messages', 'yes')

--- a/init.lua
+++ b/init.lua
@@ -60,7 +60,7 @@ local other = {
 -- Settings are read from your minetest.conf
 -- UNTOGGLABLE_DEATH_MESSAGES prevents all players from toggling their death messages if set to true,
 -- and death messages will always be sent. The default is false
-UNTOGGLABLE_DEATH_MESSAGES = minetest.settings:get_bool("disable_public_death_message_toggling", false)
+local UNTOGGLABLE_DEATH_MESSAGES = minetest.settings:get_bool("public_death_messages_togglable", false)
 
 function send_death_message(cause, victim, killer)
     local meta = victim:get_meta()
@@ -134,8 +134,7 @@ minetest.register_chatcommand('toggle_death_messages', {
         local show_death_messages = meta:get_string('show_death_messages')
 
         if UNTOGGLABLE_DEATH_MESSAGES == true then
-	    -- Notifies the player that death messages cannot be toggled and are always enabled
-	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Death messages cannot be disabled here, all will be revealed!')))
+	    minetest.chat_send_player(name, minetest.colorize('orangered', S('Your death messages cannot be disabled in this server')))
 
         elseif show_death_messages == '' or show_death_messages == 'yes' then
             -- Turn death messages off

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -28,4 +28,4 @@
 Toggles death messages appearing in chat when you die=
 You will no longer send death messages=
 You will now send death messages=
-Death messages cannot be disabled here, all will be revealed!=
+Your death messages cannot be disabled in this server=

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -28,4 +28,4 @@
 Toggles death messages appearing in chat when you die=
 You will no longer send death messages=
 You will now send death messages=
-Death messages cannot be disabled in this server=
+Death messages cannot be disabled on this server=

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -28,3 +28,4 @@
 Toggles death messages appearing in chat when you die=
 You will no longer send death messages=
 You will now send death messages=
+Death messages cannot be disabled here, all will be revealed!=

--- a/locale/template.txt
+++ b/locale/template.txt
@@ -28,4 +28,4 @@
 Toggles death messages appearing in chat when you die=
 You will no longer send death messages=
 You will now send death messages=
-Your death messages cannot be disabled in this server=
+Death messages cannot be disabled in this server=

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,4 @@
 # By default, everyone can toggle their own death messages.
-# Setting this option to false will deny toggling for all players,
-# and messages will always be sent.
-public_death_messages_togglable (Determines whether death messages can be toggled or not) bool true
+# Setting this option to false will deny death message
+# toggleablility to all players, and they are always enabled.
+public_death_messages_toggleable (Determines whether death messages can be toggled or not) bool true

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,2 +1,4 @@
-# Disables message toggling, false by default
-disable_public_death_message_toggling (By default, everyone can toggle their own death messages. Setting this option to true will deny toggling for all players, and messages will always be sent.) bool false
+# By default, everyone can toggle their own death messages.
+# Setting this option to true will deny toggling for all players,
+# and messages will always be sent.
+public_death_messages_togglable (Death messages cannot be toggled and are always enabled) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,0 +1,2 @@
+# Disables message toggling, false by default
+disable_public_death_message_toggling (By default, everyone can toggle their own death messages. Setting this option to true will deny toggling for all players, and messages will always be sent.) bool false

--- a/settingtypes.txt
+++ b/settingtypes.txt
@@ -1,4 +1,4 @@
 # By default, everyone can toggle their own death messages.
-# Setting this option to true will deny toggling for all players,
+# Setting this option to false will deny toggling for all players,
 # and messages will always be sent.
-public_death_messages_togglable (Death messages cannot be toggled and are always enabled) bool false
+public_death_messages_togglable (Determines whether death messages can be toggled or not) bool true


### PR DESCRIPTION
More minimal changes this time, adds a setting which always enables death messages for all players. As well as the locale entry and a note in the README.